### PR TITLE
Deprecated Parameters

### DIFF
--- a/.github/workflows/roxygenize.yml
+++ b/.github/workflows/roxygenize.yml
@@ -23,7 +23,8 @@ jobs:
         with:
           fetch-depth: 0
           # extra token required to trigger github actions again on commit
-          token: ${{ secrets.BOT_GH_TOKEN }}
+          # fall back to GITHUB_TOKEN when a PR is made from a fork
+          token: ${{ secrets.BOT_GH_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Setup R
         uses: r-lib/actions/setup-r@v2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Depends:
 Imports:
     dplyr (>= 0.7),
     magrittr (>= 1.5),
-    readr (>= 1.1),
+    readr (>= 1.4.0),
     readxl (>= 1.0),
     testit (>= 0.7),
     tibble (>= 1.4.2),

--- a/R/custom_deconvolution_methods.R
+++ b/R/custom_deconvolution_methods.R
@@ -64,8 +64,8 @@ deconvolute_cibersort_custom <- function(gene_expression_matrix, signature_matri
 
   temp.expression.file <- tempfile()
   temp.signature.file <- tempfile()
-  write_tsv(as_tibble(gene_expression_matrix, rownames = "gene_symbol"), path = temp.expression.file)
-  write_tsv(as_tibble(signature_matrix, rownames = "gene_symbol"), path = temp.signature.file)
+  write_tsv(as_tibble(gene_expression_matrix, rownames = "gene_symbol"), file = temp.expression.file)
+  write_tsv(as_tibble(signature_matrix, rownames = "gene_symbol"), file = temp.signature.file)
 
 
   arguments <- dots_list(temp.signature.file, temp.expression.file,

--- a/R/immune_deconvolution_methods.R
+++ b/R/immune_deconvolution_methods.R
@@ -254,7 +254,7 @@ deconvolute_cibersort <- function(gene_expression_matrix,
   source(get("cibersort_binary", envir = config_env))
 
   tmp_mat <- tempfile()
-  write_tsv(as_tibble(gene_expression_matrix, rownames = "gene_symbol"), path = tmp_mat)
+  write_tsv(as_tibble(gene_expression_matrix, rownames = "gene_symbol"), file = tmp_mat)
 
   arguments <- dots_list(get("cibersort_mat", envir = config_env), tmp_mat,
     perm = 0,

--- a/R/mouse_deconvolution_methods.R
+++ b/R/mouse_deconvolution_methods.R
@@ -94,7 +94,7 @@ deconvolute_seqimmucc <- function(gene_expression_matrix,
 
     temp.expression.file <- tempfile()
 
-    write_tsv(as_tibble(gene_expression_matrix, rownames = "gene_symbol"), path = temp.expression.file)
+    write_tsv(as_tibble(gene_expression_matrix, rownames = "gene_symbol"), file = temp.expression.file)
     perm <- 100
     # results = CIBERSORT(signature.path, temp.expression.file, perm, QN=FALSE, ...)
     # results = results %>%


### PR DESCRIPTION
In readr 1.4.0 the `path` parameter from the `write_tsv()` function has been renamed to `file`. "path" is now deprecated. See attached documentation and release notes. 

Documentation: 
https://readr.tidyverse.org/reference/write_delim.html#:~:text=()%0A)-,write_tsv(,-x%2C%0A%20%20file
Release notes: 
https://www.tidyverse.org/blog/2020/10/readr-1-4-0/#argument-name-consistency:~:text=As%20of%20readr,is%20now%20deprecated.

Edit: Since immunedeconv depends on readr>=1.1 it could make sense to change the version in DESCRIPTION to >=1.4.0. 